### PR TITLE
fix: wording in instruction change A=>B in no.4

### DIFF
--- a/signaling.html
+++ b/signaling.html
@@ -34,7 +34,7 @@ In this setup, there are two machines, referred here as <strong>Machine A</stron
     <li>On <strong>Machine A</strong>, click <code>createOffer</code> and copy the offer to the clipboard.</li>
     <li>On <strong>Machine A</strong>, call <code>setLocalDescription</code> with the offer.</li>
     <li>On <strong>Machine B</strong>, call <code>setRemoteDescription</code> with the offer.</li>
-    <li>On <strong>Machine A</strong>, click <code>createAnswer</code> and copy the answer to the clipboard.</li>
+    <li>On <strong>Machine B</strong>, click <code>createAnswer</code> and copy the answer to the clipboard.</li>
     <li>On <strong>Machine B</strong>, call <code>setLocalDescription</code> with the answer.</li>
     <li>On <strong>Machine A</strong>, call <code>setRemoteDescription</code> with the answer.</li>
     <li>On <strong>Machine A</strong>, copy <code>ICE candidate</code> to the clipboard.</li>


### PR DESCRIPTION
Hi Mr.Pawit,

It is very nice project.
I would like to help cross check.
From your video. In instruction number 4, It should be `Machine B` that click `createAnswer` first.


# Screenshot
![image](https://user-images.githubusercontent.com/11013287/135745554-1cb2e8b2-0751-455f-a6f3-6c567b5bc0ad.png)


https://www.youtube.com/watch?v=NJdkgs6hYU0
